### PR TITLE
Updated for new versions of Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ Using docker-compose to run Prometheus &amp; Grafana on a Raspberry Pi
 ## Install Docker & docker-compose
 
 Instructions from [dev.to](https://dev.to/rohansawant/installing-docker-and-docker-compose-on-the-raspberry-pi-in-5-simple-steps-3mgl)
+this is now fairly out of date as Compose is now part of the Docker install
 
 * Install docker `curl -sSL https://get.docker.com | sh`
 * Add permissions for user pi to run docker commands `sudo usermod -aG docker pi`
-* Install docker-compose `sudo pip3 install docker-compose`
 
 ## Run Prometheus & Grafana
 
-* Build and run `docker-compose up --build`
-* Or run in the background `docker-compose up -d`
+* Build and run `sudo docker compose up --build`
+* Or run in the background `sudo docker compose up -d`
 * Prometheus should now be running at `http://raspberrypi.local:9090`
 * Grafana should now be running at `http://raspberrypi.local:3000`
 


### PR DESCRIPTION
Compose is now part of Docker, so a separate install is not needed and will likely fail anyway due to dependencies for rust

Signed-of-by: James Hartley<james@hartleyns.com>